### PR TITLE
EMBCESSMOD-2972: fix for support reprint reasons

### DIFF
--- a/responders/src/API/EMBC.Responders.API/Controllers/RegistrationsController.Supports.cs
+++ b/responders/src/API/EMBC.Responders.API/Controllers/RegistrationsController.Supports.cs
@@ -413,11 +413,11 @@ namespace EMBC.Responders.API.Controllers
         [Description("Error On Printed Referral")]
         ErrorOnPrintedReferral,
 
-        [Description("Printed Error")]
-        PrintedError,
+        [Description("Printer Error")]
+        PrinterError,
 
-        [Description("Evacuee Lost Referral")]
-        EvacueeLostReferral
+        [Description("Evacuee Lost the Referral")]
+        EvacueeLostTheReferral
     }
 
     public class ReferralPrintRequestResponse

--- a/responders/src/UI/embc-responder/src/app/core/api/models/support-reprint-reason.ts
+++ b/responders/src/UI/embc-responder/src/app/core/api/models/support-reprint-reason.ts
@@ -2,6 +2,6 @@
 /* eslint-disable */
 export enum SupportReprintReason {
   ErrorOnPrintedReferral = 'ErrorOnPrintedReferral',
-  PrintedError = 'PrintedError',
-  EvacueeLostReferral = 'EvacueeLostReferral'
+  PrinterError = 'PrinterError',
+  EvacueeLostTheReferral = 'EvacueeLostTheReferral'
 }

--- a/responders/src/UI/embc-responder/src/app/shared/components/dialog-components/reprint-referral-dialog/reprint-referral-dialog.component.ts
+++ b/responders/src/UI/embc-responder/src/app/shared/components/dialog-components/reprint-referral-dialog/reprint-referral-dialog.component.ts
@@ -62,11 +62,6 @@ export class ReprintReferralDialogComponent implements OnInit {
    * @returns the same reason for reprinting with spaces between words.
    */
   splitString(reasonOption: string): string {
-    const stringArray: string[] = reasonOption.split(/(?=[A-Z])/);
-    let result = '';
-    stringArray.forEach((word) => {
-      result += word + ' ';
-    });
-    return result;
+    return reasonOption.split(/(?=[A-Z])/).join(' ');
   }
 }

--- a/responders/src/UI/embc-responder/src/app/shared/components/dialog-components/void-referral-dialog/void-referral-dialog.component.ts
+++ b/responders/src/UI/embc-responder/src/app/shared/components/dialog-components/void-referral-dialog/void-referral-dialog.component.ts
@@ -62,11 +62,6 @@ export class VoidReferralDialogComponent implements OnInit {
    * @returns the same reason for reprinting with spaces between words.
    */
   splitString(reasonOption: string): string {
-    const stringArray: string[] = reasonOption.split(/(?=[A-Z])/);
-    let result = '';
-    stringArray.forEach((word) => {
-      result += word + ' ';
-    });
-    return result;
+    return reasonOption.split(/(?=[A-Z])/).join(' ');
   }
 }


### PR DESCRIPTION
cleanup splitString() - used to display the reprint reasons