### PR TITLE
EMBCESSMOD-3114: Update Evacuated From and Evacuated To fields when user deselects these options

### DIFF
--- a/responders/src/UI/embc-responder/src/app/feature-components/reporting/reporting.component.html
+++ b/responders/src/UI/embc-responder/src/app/feature-components/reporting/reporting.component.html
@@ -54,6 +54,7 @@
                   matInput
                   placeholder="Evacuated From"
                   [matAutocomplete]="auto"
+                  (change)="getEvacuatedFromBlank()"
                 />
                 <mat-autocomplete
                   #auto="matAutocomplete"
@@ -85,6 +86,7 @@
                   matInput
                   placeholder="Evacuated To"
                   [matAutocomplete]="autoTo"
+                  (change)="getEvacuatedToBlank()"
                 />
                 <mat-autocomplete
                   #autoTo="matAutocomplete"

--- a/responders/src/UI/embc-responder/src/app/feature-components/reporting/reporting.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/reporting/reporting.component.ts
@@ -133,9 +133,21 @@ export class ReportingComponent implements OnInit {
     this.reportForm.get('evacuatedFromCommCode').setValue(community.code);
   }
 
+  getEvacuatedFromBlank() {
+    if (this.reportForm.get('evacuatedFrom').value === '') {
+      this.reportForm.get('evacuatedFromCommCode').setValue('');
+    }
+  }
+
   getEvacuatedTo(community: Community) {
     this.reportForm.get('evacuatedTo').setValue(community);
     this.reportForm.get('evacuatedToCommCode').setValue(community.code);
+  }
+
+  getEvacuatedToBlank() {
+    if (this.reportForm.get('evacuatedTo').value === '') {
+      this.reportForm.get('evacuatedToCommCode').setValue('');
+    }
   }
 
   /**


### PR DESCRIPTION
When the user selects a city and then deselects it, the UI was not updating the deselection and was sending to the API the evacuatedFrom or evacuatedTo field that was selected previously.