### PR TITLE
EMBCESSMOD-5550: Fix showing note box

### DIFF
--- a/registrants/src/UI/embc-registrant/src/app/feature-components/self-serve-support/self-serve-support-details-form/self-serve-support-details-form.component.html
+++ b/registrants/src/UI/embc-registrant/src/app/feature-components/self-serve-support/self-serve-support-details-form/self-serve-support-details-form.component.html
@@ -52,7 +52,7 @@
         appearance="outlined"
         [class.support-one-time-used]="
           supportEligibilityStateSettings[SelfServeSupportType.FoodGroceries] ===
-            SelfServeSupportEligibilityState.UnavailableOneTimeUsed ||
+            SelfServeSupportEligibilityState.UnavailableOneTimeUsed &&
           supportEligibilityStateSettings[SelfServeSupportType.FoodRestaurant] ===
             SelfServeSupportEligibilityState.UnavailableOneTimeUsed
         "


### PR DESCRIPTION
- Apply `support-one-time-used` css only when both food sub categories are `unavailableonetimeused`


![image](https://github.com/bcgov/embc-ess-mod/assets/395381/8701dbdd-08a7-4878-96fc-e343583ae265)
