### PR TITLE
EMBCESSMOD-4781: Catch for null values in era_EvacuationFileid query

### DIFF
--- a/ess/src/API/EMBC.ESS/Resources/Evacuations/EvacuationRepository.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Evacuations/EvacuationRepository.cs
@@ -396,7 +396,7 @@ public class EvacuationRepository : IEvacuationRepository
 
         return (await memberQuery.GetAllPagesAsync(ct))
             .Select(m => m.era_EvacuationFileid)
-            .Where(f => f.statecode == (int)EntityState.Active);
+            .Where(f => f != null && f.statecode == (int)EntityState.Active);
     }
 
     private static async Task<IEnumerable<era_evacuationfile>> QueryEvacuationFiles(EssContext ctx, EvacuationFilesQuery query, CancellationToken ct)


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/EMBCESSMOD-4781

In the query to fetch household member files, sometimes household members would not have any files, so the query would fail resulting in a failed search query for a user.