### PR TITLE
DEVOPS-43: Responder Portal Support Limits

### DIFF
--- a/ess/src/API/EMBC.ESS/Resources/Tasks/Contract.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/Contract.cs
@@ -55,13 +55,7 @@ public record SupportConfiguration
     public SupportType SupportType { get; set; }
     public DateTime SupportLimitStartDate { get; set; }
     public DateTime SupportLimitEndDate { get; set; }
-    public SupportExtensionAvailable ExtensionAvailable { get; set; }
-}
-
-public enum SupportExtensionAvailable
-{
-    No = 0,
-    Yes = 1
+    public bool ExtensionAvailable { get; set; }
 }
 
 public enum SupportType

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/Contract.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/Contract.cs
@@ -47,11 +47,21 @@ public record EssTask : Task
     public bool RemoteExtensionsEnabled { get; set; }
     public bool SelfServeEnabled { get; set; }
     public IEnumerable<SupportConfiguration> EnabledSupports { get; set; } = [];
+    public IEnumerable<SupportConfiguration> SupportLimits { get; set; } = [];
 }
 
 public record SupportConfiguration
 {
     public SupportType SupportType { get; set; }
+    public DateTime SupportLimitStartDate { get; set; }
+    public DateTime SupportLimitEndDate { get; set; }
+    public SupportExtensionAvailable ExtensionAvailable { get; set; }
+}
+
+public enum SupportExtensionAvailable
+{
+    No = 0,
+    Yes = 1
 }
 
 public enum SupportType

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
@@ -40,10 +40,5 @@ public class Mappings : Profile
             .ForMember(dest => dest.SupportLimitEndDate, opts => opts.MapFrom(src => src.SupportLimitEndDate))
             .ForMember(dest => dest.ExtensionAvailable, opts => opts.MapFrom(src => src.ExtensionAvailable))
         ;
-
-        CreateMap<EMBC.ESS.Resources.Tasks.EssTask, EMBC.ESS.Shared.Contracts.Events.IncidentTask>()
-            .ForMember(dest => dest.SupportLimits, opts => opts.MapFrom(src => src.SupportLimits))
-            .ForMember(dest => dest.Status, opts => opts.MapFrom(src => src.Status))
-        ;
     }
 }

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
@@ -20,10 +20,30 @@ public class Mappings : Profile
             .ForMember(d => d.SelfServeEnabled, opts => opts.MapFrom(s => s.era_selfservetoggle))
             .ForMember(d => d.AutoApprovedEnabled, opts => opts.Ignore())
             .ForMember(d => d.EnabledSupports, opts => opts.MapFrom(s => s.era_era_task_era_selfservesupportlimits_Task.Where(sl => sl.statuscode == 1)))
+            .ForMember(d => d.SupportLimits, opts => opts.MapFrom(s => s.era_era_task_era_supportlimit_Task.Where(sl => sl.statuscode == 1)))
             ;
 
         CreateMap<era_selfservesupportlimits, SupportConfiguration>()
             .ForMember(d => d.SupportType, opts => opts.MapFrom(s => s.era_supporttypeoption))
             ;
+
+        CreateMap<era_supportlimit, SupportConfiguration>()
+            .ForMember(d => d.SupportType, opts => opts.MapFrom(s => s.era_supporttypeoption))
+            .ForMember(d => d.ExtensionAvailable, opts => opts.MapFrom(s => s.era_extensionavailable))
+            .ForMember(d => d.SupportLimitStartDate, opts => opts.MapFrom(s => s.era_supportlimitstartdate.HasValue ? s.era_supportlimitstartdate.Value.UtcDateTime : (DateTime?)null))
+            .ForMember(d => d.SupportLimitEndDate, opts => opts.MapFrom(s => s.era_supportlimitenddate.HasValue ? s.era_supportlimitenddate.Value.UtcDateTime : (DateTime?)null))
+        ;
+
+        CreateMap<EMBC.ESS.Resources.Tasks.SupportConfiguration, EMBC.ESS.Shared.Contracts.Events.SupportLimits>()
+            .ForMember(dest => dest.SupportType, opts => opts.MapFrom(src => src.SupportType))
+            .ForMember(dest => dest.SupportLimitStartDate, opts => opts.MapFrom(src => src.SupportLimitStartDate))
+            .ForMember(dest => dest.SupportLimitEndDate, opts => opts.MapFrom(src => src.SupportLimitEndDate))
+            .ForMember(dest => dest.ExtensionAvailable, opts => opts.MapFrom(src => src.ExtensionAvailable))
+        ;
+
+        CreateMap<EMBC.ESS.Resources.Tasks.EssTask, EMBC.ESS.Shared.Contracts.Events.IncidentTask>()
+            .ForMember(dest => dest.SupportLimits, opts => opts.MapFrom(src => src.SupportLimits))
+            .ForMember(dest => dest.Status, opts => opts.MapFrom(src => src.Status))
+        ;
     }
 }

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/Mappings.cs
@@ -25,6 +25,9 @@ public class Mappings : Profile
 
         CreateMap<era_selfservesupportlimits, SupportConfiguration>()
             .ForMember(d => d.SupportType, opts => opts.MapFrom(s => s.era_supporttypeoption))
+            .ForMember(d => d.ExtensionAvailable, opts => opts.MapFrom(s => s.era_extensionavailable))
+            .ForMember(d => d.SupportLimitStartDate, opts => opts.MapFrom(s => s.era_supportlimitstartdate.HasValue ? s.era_supportlimitstartdate.Value.UtcDateTime : (DateTime?)null))
+            .ForMember(d => d.SupportLimitEndDate, opts => opts.MapFrom(s => s.era_supportlimitenddate.HasValue ? s.era_supportlimitenddate.Value.UtcDateTime : (DateTime?)null))
             ;
 
         CreateMap<era_supportlimit, SupportConfiguration>()

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/TaskRepository.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/TaskRepository.cs
@@ -76,7 +76,6 @@ namespace EMBC.ESS.Resources.Tasks
 
                 var supportLimits = (await essContext.era_supportlimits.Expand(sl => sl.era_SupportType).Where(sl => sl._era_task_value == t.era_taskid).GetAllPagesAsync(ct1)).ToList();
                 t.era_era_task_era_supportlimit_Task = new System.Collections.ObjectModel.Collection<era_supportlimit>(supportLimits);
-
             });
 
             return tasks;

--- a/ess/src/API/EMBC.ESS/Resources/Tasks/TaskRepository.cs
+++ b/ess/src/API/EMBC.ESS/Resources/Tasks/TaskRepository.cs
@@ -65,6 +65,7 @@ namespace EMBC.ESS.Resources.Tasks
                    essContext.era_tasks
                    .Expand(t => t.era_JurisdictionID)
                    .Expand(t => t.era_era_task_era_selfservesupportlimits_Task)
+                   .Expand(t => t.era_era_task_era_supportlimit_Task)
                    .Where(t => t.era_name == query.ById)
                    .GetAllPagesAsync(ct)).ToList();
 
@@ -72,6 +73,10 @@ namespace EMBC.ESS.Resources.Tasks
             {
                 var selfServeSupports = (await essContext.era_selfservesupportlimitses.Expand(sl => sl.era_SupportType).Where(sl => sl._era_task_value == t.era_taskid).GetAllPagesAsync(ct1)).ToList();
                 t.era_era_task_era_selfservesupportlimits_Task = new System.Collections.ObjectModel.Collection<era_selfservesupportlimits>(selfServeSupports);
+
+                var supportLimits = (await essContext.era_supportlimits.Expand(sl => sl.era_SupportType).Where(sl => sl._era_task_value == t.era_taskid).GetAllPagesAsync(ct1)).ToList();
+                t.era_era_task_era_supportlimit_Task = new System.Collections.ObjectModel.Collection<era_supportlimit>(supportLimits);
+
             });
 
             return tasks;

--- a/responders/src/API/EMBC.Responders.API/Controllers/TasksController.cs
+++ b/responders/src/API/EMBC.Responders.API/Controllers/TasksController.cs
@@ -45,6 +45,7 @@ namespace EMBC.Responders.API.Controllers
             if (task == null) return NotFound(taskId);
             var mappedTask = mapper.Map<ESSTask>(task);
             mappedTask.Workflows = GetTaskWorkflows(task);
+            mappedTask.SupportLimits = GetTaskSupportLimits(task);
             return Ok(mappedTask);
         }
 
@@ -58,6 +59,24 @@ namespace EMBC.Responders.API.Controllers
                 new TaskWorkflow { Name = "case-notes",  Enabled = incidentTask.Status == IncidentTaskStatus.Active || incidentTask.Status == IncidentTaskStatus.Expired },
             };
             return workflows;
+        }
+
+        private static IEnumerable<SupportConfiguration> GetTaskSupportLimits(IncidentTask incidentTask)
+        {
+            if (incidentTask.SupportLimits == null || !incidentTask.SupportLimits.Any())
+            {
+                return Enumerable.Empty<SupportConfiguration>();
+            }
+
+            var supportLimits = incidentTask.SupportLimits.Select(sl => new SupportConfiguration
+            {
+                SupportType = sl.SupportType,
+                SupportLimitStartDate = sl.SupportLimitStartDate,
+                SupportLimitEndDate = sl.SupportLimitEndDate,
+                ExtensionAvailable = sl.ExtensionAvailable
+            });
+
+            return supportLimits;
         }
 
         [HttpGet("{taskId}/suppliers")]
@@ -96,6 +115,7 @@ namespace EMBC.Responders.API.Controllers
         public string Description { get; set; }
         public string Status { get; set; }
         public IEnumerable<TaskWorkflow> Workflows { get; set; } = Array.Empty<TaskWorkflow>();
+        public IEnumerable<SupportConfiguration> SupportLimits { get; set; } = Array.Empty<SupportConfiguration>();
     }
 
     public class TaskWorkflow
@@ -125,7 +145,8 @@ namespace EMBC.Responders.API.Controllers
         public TaskMapping()
         {
             CreateMap<IncidentTask, ESSTask>()
-                .ForMember(d => d.Workflows, opts => opts.Ignore());
+                .ForMember(d => d.Workflows, opts => opts.Ignore())
+                .ForMember(d => d.SupportLimits, opts => opts.MapFrom(s => s.SupportLimits));
             CreateMap<SupplierDetails, SuppliersListItem>();
         }
     }

--- a/responders/src/API/EMBC.Responders.API/Controllers/TasksController.cs
+++ b/responders/src/API/EMBC.Responders.API/Controllers/TasksController.cs
@@ -61,14 +61,14 @@ namespace EMBC.Responders.API.Controllers
             return workflows;
         }
 
-        private static IEnumerable<SupportConfiguration> GetTaskSupportLimits(IncidentTask incidentTask)
+        private static IEnumerable<SupportLimits> GetTaskSupportLimits(IncidentTask incidentTask)
         {
             if (incidentTask.SupportLimits == null || !incidentTask.SupportLimits.Any())
             {
-                return Enumerable.Empty<SupportConfiguration>();
+                return Enumerable.Empty<SupportLimits>();
             }
 
-            var supportLimits = incidentTask.SupportLimits.Select(sl => new SupportConfiguration
+            var supportLimits = incidentTask.SupportLimits.Select(sl => new SupportLimits
             {
                 SupportType = sl.SupportType,
                 SupportLimitStartDate = sl.SupportLimitStartDate,
@@ -115,7 +115,7 @@ namespace EMBC.Responders.API.Controllers
         public string Description { get; set; }
         public string Status { get; set; }
         public IEnumerable<TaskWorkflow> Workflows { get; set; } = Array.Empty<TaskWorkflow>();
-        public IEnumerable<SupportConfiguration> SupportLimits { get; set; } = Array.Empty<SupportConfiguration>();
+        public IEnumerable<SupportLimits> SupportLimits { get; set; } = Array.Empty<SupportLimits>();
     }
 
     public class TaskWorkflow

--- a/responders/src/UI/embc-responder/src/app/core/api/models/ess-task.ts
+++ b/responders/src/UI/embc-responder/src/app/core/api/models/ess-task.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import { TaskWorkflow } from '../models/task-workflow';
+import { SupportLimit } from './support-limit';
 export interface EssTask {
   communityCode?: string | null;
   description?: string | null;
@@ -9,4 +10,5 @@ export interface EssTask {
   startDate?: string;
   status?: string | null;
   workflows?: Array<TaskWorkflow> | null;
+  supportLimits?: Array<SupportLimit> | null;
 }

--- a/responders/src/UI/embc-responder/src/app/core/api/models/support-limit.ts
+++ b/responders/src/UI/embc-responder/src/app/core/api/models/support-limit.ts
@@ -1,0 +1,9 @@
+/* tslint:disable */
+/* eslint-disable */
+import { SupportSubCategory } from './support-sub-category';
+export interface SupportLimit {
+    supportLimitStartDate: Date;
+    supportLimitEndDate: Date;
+    extensionAvailable: boolean;
+    supportType: SupportSubCategory
+}

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/step-supports/step-supports.service.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/step-supports/step-supports.service.ts
@@ -58,7 +58,7 @@ export class StepSupportsService {
     private appBaseService: AppBaseService,
     private computeState: ComputeRulesService,
     private evacueeSessionService: EvacueeSessionService
-  ) { }
+  ) {}
 
   set selectedSupportDetail(selectedSupportDetailVal: Support) {
     this.selectedSupportDetailVal = selectedSupportDetailVal;
@@ -101,23 +101,25 @@ export class StepSupportsService {
   }
 
   fetchSupportLimits(): Observable<SupportLimit[]> {
-    return this.taskService.tasksGetTask({
-      taskId: this.userService?.currentProfile?.taskNumber
-    }).pipe(
-      map((task) => {
-        const supportLimits: SupportLimit[] = task.supportLimits.map((supportLimit) => {
-          return {
-            supportLimitStartDate: supportLimit.supportLimitStartDate,
-            supportLimitEndDate: supportLimit.supportLimitEndDate,
-            extensionAvailable: supportLimit.extensionAvailable,
-            supportType: supportLimit.supportType
-          };
-        });
-
-        this.setStoredSupportLimits(supportLimits);
-        return supportLimits;
+    return this.taskService
+      .tasksGetTask({
+        taskId: this.userService?.currentProfile?.taskNumber
       })
-    );
+      .pipe(
+        map((task) => {
+          const supportLimits: SupportLimit[] = task.supportLimits.map((supportLimit) => {
+            return {
+              supportLimitStartDate: supportLimit.supportLimitStartDate,
+              supportLimitEndDate: supportLimit.supportLimitEndDate,
+              extensionAvailable: supportLimit.extensionAvailable,
+              supportType: supportLimit.supportType
+            };
+          });
+
+          this.setStoredSupportLimits(supportLimits);
+          return supportLimits;
+        })
+      );
   }
 
   set supportTypeToAdd(supportTypeToAddVal: Code) {
@@ -188,29 +190,29 @@ export class StepSupportsService {
     const referral: Referral | Interac =
       method === SupportMethod.Referral
         ? {
-          manualReferralId:
-            this.supportDetails.externalReferenceId !== undefined
-              ? 'R' + this.supportDetails.externalReferenceId
-              : '',
-          issuedToPersonName:
-            this.supportTypeToAdd.value === SupportSubCategory.Lodging_Allowance
-              ? this.supportDelivery.details.hostName
-              : (this.supportDelivery.issuedTo as any) !== 'Someone else'
-                ? this.supportDelivery.issuedTo.lastName + ', ' + this.supportDelivery.issuedTo.firstName
-                : this.supportDelivery.name,
+            manualReferralId:
+              this.supportDetails.externalReferenceId !== undefined
+                ? 'R' + this.supportDetails.externalReferenceId
+                : '',
+            issuedToPersonName:
+              this.supportTypeToAdd.value === SupportSubCategory.Lodging_Allowance
+                ? this.supportDelivery.details.hostName
+                : (this.supportDelivery.issuedTo as any) !== 'Someone else'
+                  ? this.supportDelivery.issuedTo.lastName + ', ' + this.supportDelivery.issuedTo.firstName
+                  : this.supportDelivery.name,
 
-          supplierAddress: this.supportDelivery.supplier.address,
-          supplierId: this.supportDelivery.supplier.id,
-          supplierName: this.supportDelivery.supplier.name,
-          supplierNotes: this.supportDelivery.supplierNote,
-          method: SupportMethod.Referral
-        }
+            supplierAddress: this.supportDelivery.supplier.address,
+            supplierId: this.supportDelivery.supplier.id,
+            supplierName: this.supportDelivery.supplier.name,
+            supplierNotes: this.supportDelivery.supplierNote,
+            method: SupportMethod.Referral
+          }
         : {
-          method: SupportMethod.ETransfer,
-          notificationEmail: this.supportDelivery.notificationEmail,
-          notificationMobile: this.supportDelivery.notificationMobile,
-          receivingRegistrantId: this.appBaseService?.appModel?.selectedProfile?.selectedEvacueeInContext.id
-        };
+            method: SupportMethod.ETransfer,
+            notificationEmail: this.supportDelivery.notificationEmail,
+            notificationMobile: this.supportDelivery.notificationMobile,
+            receivingRegistrantId: this.appBaseService?.appModel?.selectedProfile?.selectedEvacueeInContext.id
+          };
     const support: Support = {
       issuedBy: this.supportDetails.issuedBy,
       issuedOn: this.supportDetails.issuedOn,

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.html
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.html
@@ -377,38 +377,50 @@
                       </p>
                     </div>
                   </div>
-
-                  <div class="row">
-                    <div class="col-md-12">
-                      <mat-checkbox
-                        id="allMembers"
-                        [checked]="isChecked()"
-                        [indeterminate]="isIndeterminate()"
-                        (change)="$event ? selectAll($event) : null"
-                        ><span class="bold">All household members</span></mat-checkbox
-                      >
-                    </div>
+                  <div class="col-md-4" *ngIf="showLoader">
+                    <app-loader [strokeWidth]="3" [diameter]="25" [showLoader]="showLoader" [color]="color">
+                    </app-loader>
                   </div>
-                  @for (member of evacueeSessionService?.evacFile?.needsAssessment?.householdMembers; track member) {
+                  <div *ngIf="!showLoader">
                     <div class="row">
                       <div class="col-md-12">
                         <mat-checkbox
-                          (click)="$event.stopPropagation()"
-                          (change)="$event ? onChange($event, member) : null"
-                          [checked]="exists(member)"
-                        >
-                          {{ member.lastName | uppercase }}, {{ member.firstName | titlecase }}</mat-checkbox
+                          id="allMembers"
+                          [checked]="isChecked()"
+                          [indeterminate]="isIndeterminate()"
+                          (change)="selectAll($event)"
+                          ><span class="bold">All household members</span></mat-checkbox
                         >
                       </div>
                     </div>
-                  }
-                  @if (
-                    supportDetailsFormControl.members.invalid &&
-                    supportDetailsFormControl.members.hasError('noSelection')
-                  ) {
-                    <mat-error class="custom-mat-error"> Required</mat-error>
-                  }
-
+                    @for (member of evacueeSessionService?.evacFile?.needsAssessment?.householdMembers; track member) {
+                      <div class="row">
+                        <div class="col-md-12">
+                          <mat-checkbox
+                            (click)="$event.stopPropagation()"
+                            (change)="$event ? onChange($event, member) : null"
+                            [disabled]="!isHouseholdMemberEligibleForSupport(member)"
+                            [checked]="exists(member)"
+                          >
+                            {{ member.lastName | uppercase }}, {{ member.firstName | titlecase }}
+                          </mat-checkbox>
+                          <!-- Display error message if the checkbox is disabled -->
+                          @if (!isHouseholdMemberEligibleForSupport(member)) {
+                            <mat-error class="custom-mat-info">
+                              {{ member.firstName | titlecase }} {{ member.lastName | titlecase }} has already received
+                              this support. Extensions for this support are not available at this time.
+                            </mat-error>
+                          }
+                        </div>
+                      </div>
+                    }
+                    @if (
+                      supportDetailsFormControl.members.invalid &&
+                      supportDetailsFormControl.members.hasError('noSelection')
+                    ) {
+                      <mat-error class="custom-mat-error"> Required</mat-error>
+                    }
+                  </div>
                   <div>
                     @switch (stepSupportsService?.supportTypeToAdd?.value) {
                       <!-- Shelter-Allowance -->

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -250,7 +250,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
       },
       error: (error) => {
         this.showLoader = false;
-        console.error("Error fetching support limits: ", error);
+        console.error('Error fetching support limits: ', error);
         this.alertService.clearAlert();
         this.alertService.setAlert('danger', globalConst.supportListerror);
         this.cdr.detectChanges();
@@ -332,10 +332,10 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
   }
 
   allMembersEligible(): boolean {
-    return this.evacueeSessionService?.evacFile?.needsAssessment?.householdMembers
-      .every(member => this.isHouseholdMemberEligibleForSupport(member));
+    return this.evacueeSessionService?.evacFile?.needsAssessment?.householdMembers.every((member) =>
+      this.isHouseholdMemberEligibleForSupport(member)
+    );
   }
-
 
   checkDateRange(): boolean {
     const selectedFromDate = new Date(this.supportDetailsForm.get('fromDate').value);

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -1,5 +1,5 @@
-import { DatePipe, NgStyle, UpperCasePipe, TitleCasePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { DatePipe, NgStyle, UpperCasePipe, TitleCasePipe, CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, ChangeDetectorRef } from '@angular/core';
 import {
   AbstractControl,
   UntypedFormArray,
@@ -54,6 +54,7 @@ import { AppLoaderComponent } from '../../../../shared/components/app-loader/app
 import { MatInput } from '@angular/material/input';
 import { MatFormField, MatPrefix, MatError, MatLabel, MatSuffix } from '@angular/material/form-field';
 import { MatCard, MatCardContent } from '@angular/material/card';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-support-details',
@@ -80,6 +81,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
     MatSelect,
     MatOption,
     MatCheckbox,
+    MatTooltipModule,
     ShelterAllowanceGroupComponent,
     FoodMealsComponent,
     FoodGroceriesComponent,
@@ -93,7 +95,8 @@ import { MatCard, MatCardContent } from '@angular/material/card';
     MatButton,
     UpperCasePipe,
     TitleCasePipe,
-    DatePipe
+    DatePipe,
+    CommonModule
   ]
 })
 export class SupportDetailsComponent implements OnInit, OnDestroy {
@@ -112,6 +115,8 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
   originalSupport: Support;
   existingSupports: Support[];
   supportListSubscription: Subscription;
+  supportLimits: any;
+  supportLimitsSubscription: Subscription;
 
   constructor(
     private router: Router,
@@ -126,6 +131,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     private referralCreationService: ReferralCreationService,
     private dateConversionService: DateConversionService,
     private computeState: ComputeRulesService,
+    private cdr: ChangeDetectorRef,
     private loadEvacueeListService: LoadEvacueeListService
   ) {
     if (this.router.getCurrentNavigation() !== null) {
@@ -235,6 +241,22 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
   };
 
   ngOnInit(): void {
+    this.showLoader = true;
+    this.supportLimitsSubscription = this.stepSupportsService.fetchSupportLimits().subscribe({
+      next: (supportLimits) => {
+        this.supportLimits = supportLimits;
+        this.showLoader = false;
+        this.cdr.detectChanges();
+      },
+      error: (error) => {
+        this.showLoader = false;
+        console.error("Error fetching support limits: ", error);
+        this.alertService.clearAlert();
+        this.alertService.setAlert('danger', globalConst.supportListerror);
+        this.cdr.detectChanges();
+      }
+    });
+
     this.supportListSubscription = this.stepSupportsService.getExistingSupportList().subscribe({
       next: (supports) => {
         this.existingSupports = supports;
@@ -277,7 +299,43 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.supportListSubscription.unsubscribe();
+    this.supportLimitsSubscription.unsubscribe();
   }
+
+  isHouseholdMemberEligibleForSupport(member: EvacuationFileHouseholdMember): boolean {
+    if (!this.supportLimits || this.supportLimits.length === 0) {
+      return true;
+    }
+    const currentSupportType = this.stepSupportsService.supportTypeToAdd.description;
+    const matchingSupportLimit = this.supportLimits.find(
+      (limit) => this.mapSupportType(limit.supportType) === currentSupportType
+    );
+    if (!matchingSupportLimit) {
+      return true;
+    }
+    if (matchingSupportLimit.extensionAvailable) {
+      return true;
+    }
+    const supportLimitStartDate = moment(matchingSupportLimit.supportLimitStartDate);
+    const supportLimitEndDate = moment(matchingSupportLimit.supportLimitEndDate);
+    const hasReceivedSupport = this.existingSupports.some((support) => {
+      const supportDate = moment(support.from);
+      return (
+        support.category === currentSupportType &&
+        support.includedHouseholdMembers?.some((m) => m === member.id) &&
+        support.status !== SupportStatus.Cancelled.toString() &&
+        support.status !== SupportStatus.Void.toString() &&
+        supportDate.isBetween(supportLimitStartDate, supportLimitEndDate, 'days', '[]')
+      );
+    });
+    return !hasReceivedSupport;
+  }
+
+  allMembersEligible(): boolean {
+    return this.evacueeSessionService?.evacFile?.needsAssessment?.householdMembers
+      .every(member => this.isHouseholdMemberEligibleForSupport(member));
+  }
+
 
   checkDateRange(): boolean {
     const selectedFromDate = new Date(this.supportDetailsForm.get('fromDate').value);
@@ -378,7 +436,9 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     if ($event.checked) {
       members.clear();
       this.evacueeSessionService?.evacFile?.needsAssessment?.householdMembers.forEach((member) => {
-        members.push(new UntypedFormControl(member));
+        if (this.isHouseholdMemberEligibleForSupport(member)) {
+          members.push(new UntypedFormControl(member));
+        }
       });
     } else {
       members.clear();
@@ -685,6 +745,33 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
 
     const largestToTime = finalTime.toTimeString().split(' ')[0];
     return largestToTime;
+  }
+
+  private mapSupportType(supportType: number): SupportSubCategory | SupportCategory {
+    switch (supportType) {
+      case 174360000:
+        return SupportSubCategory.Food_Groceries;
+      case 174360001:
+        return SupportSubCategory.Food_Restaurant;
+      case 174360002:
+        return SupportSubCategory.Lodging_Hotel;
+      case 174360003:
+        return SupportSubCategory.Lodging_Billeting;
+      case 174360004:
+        return SupportSubCategory.Lodging_Group;
+      case 174360005:
+        return SupportCategory.Incidentals;
+      case 174360006:
+        return SupportCategory.Clothing;
+      case 174360007:
+        return SupportSubCategory.Transportation_Taxi;
+      case 174360008:
+        return SupportSubCategory.Transportation_Other;
+      case 174360009:
+        return SupportSubCategory.Lodging_Allowance;
+      default:
+        return SupportCategory.Unknown;
+    }
   }
 
   private setToTime() {

--- a/responders/src/UI/embc-responder/src/styles/styles.scss
+++ b/responders/src/UI/embc-responder/src/styles/styles.scss
@@ -371,6 +371,11 @@ mat-form-field {
   font-size: 75%;
 }
 
+.custom-mat-info {
+  font-size: 75%;
+  color: #000 !important;
+}
+
 .mat-mdc-dialog-container {
   border-radius: 0px !important;
 }

--- a/shared/src/EMBC.ESS.Shared.Contracts/Events/Tasks.cs
+++ b/shared/src/EMBC.ESS.Shared.Contracts/Events/Tasks.cs
@@ -53,13 +53,7 @@ namespace EMBC.ESS.Shared.Contracts.Events
         public SupportType SupportType { get; set; }
         public DateTime SupportLimitStartDate { get; set; }
         public DateTime SupportLimitEndDate { get; set; }
-        public SupportExtensionAvailable ExtensionAvailable { get; set; }
-    }
-
-    public enum SupportExtensionAvailable
-    {
-        No = 0,
-        Yes = 1
+        public bool ExtensionAvailable { get; set; }
     }
 
     public enum SupportType

--- a/shared/src/EMBC.ESS.Shared.Contracts/Events/Tasks.cs
+++ b/shared/src/EMBC.ESS.Shared.Contracts/Events/Tasks.cs
@@ -39,11 +39,40 @@ namespace EMBC.ESS.Shared.Contracts.Events
         public IncidentTaskStatus Status { get; set; }
         public bool RemoteExtensionsEnabled { get; set; }
         public bool SelfServeEnabled { get; set; }
+        public IEnumerable<SupportLimits> SupportLimits { get; set; }
     }
 
     public enum IncidentTaskStatus
     {
         Active,
         Expired
+    }
+
+    public record SupportLimits
+    {
+        public SupportType SupportType { get; set; }
+        public DateTime SupportLimitStartDate { get; set; }
+        public DateTime SupportLimitEndDate { get; set; }
+        public SupportExtensionAvailable ExtensionAvailable { get; set; }
+    }
+
+    public enum SupportExtensionAvailable
+    {
+        No = 0,
+        Yes = 1
+    }
+
+    public enum SupportType
+    {
+        FoodGroceries = 174360000,
+        FoodRestaurant = 174360001,
+        ShelterHotel = 174360002,
+        ShelterBilleting = 174360003,
+        ShelterGroup = 174360004,
+        Incidentals = 174360005,
+        Clothing = 174360006,
+        TransporationTaxi = 174360007,
+        TransportationOther = 174360008,
+        ShelterAllowance = 174360009
     }
 }


### PR DESCRIPTION
Ticket: https://emcr.atlassian.net/browse/DEVOPS-43

First pass on Support Limits functionality in responder portal.

When a task is queried from the backend, it now passes along information about the support limits for that task.

In the portal, a check is done when a support is being issued or extended which checks several conditions including whether support limits are defined, if extensions are available, and if the household member has already received this type of support in the defined period for the same file.

Future work will check across multiple tasks and files for duplicate supports once the fuzzy search work in DEVOPS-36 is complete.