### PR TITLE
Update to reflect location of Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ If you would like to contribute, please see our [Contributing](./CONTRIBUTING.md
 
 Please note that this project is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+### Contributing to Helm
+
+Helm is utilized as ERA's Infrastructure as Code (IaC) tool, outlining and templating all of the resources required to operate and deploy the application on a Kubernetes cluster.
+
+This part of the code base can be found in [`tools/helm/charts/era`](tools/helm/charts/era).
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
It was found that the README was lacking in specificity in regards to the location of ESS' Helm chart and related templates. The README for this codebase has now since been updated to reflect it as it is not present in the private `bcgov-c` repository.