### PR TITLE
DEVOPS-125 Fix for Number of support days

### DIFF
--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -504,7 +504,12 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
       const fromTime = this.supportDetailsForm.get('fromTime').value;
       const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
       let totalDays = days;
-      if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
+      if (
+        afterMidnightBeforeSix &&
+        (currentSupportType === SupportSubCategory.Lodging_Hotel ||
+          currentSupportType === SupportSubCategory.Lodging_Allowance ||
+          currentSupportType === SupportSubCategory.Lodging_Group)
+      ) {
         totalDays -= 1;
       }
       const finalValue = this.datePipe.transform(date.setDate(date.getDate() + totalDays), 'MM/dd/yyyy');
@@ -525,7 +530,12 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
     const date = new Date(currentVal);
     let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days), 'MM/dd/yyyy');
-    if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
+    if (
+      afterMidnightBeforeSix &&
+      (currentSupportType === SupportSubCategory.Lodging_Hotel ||
+        currentSupportType === SupportSubCategory.Lodging_Allowance ||
+        currentSupportType === SupportSubCategory.Lodging_Group)
+    ) {
       finalValue = this.datePipe.transform(date.setDate(date.getDate() + days - 1), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
     } else {
@@ -551,7 +561,12 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     if (days > 30) {
       this.supportDetailsForm.get('noOfDays').patchValue(null);
     } else {
-      if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
+      if (
+        afterMidnightBeforeSix &&
+        (currentSupportType === SupportSubCategory.Lodging_Hotel ||
+          currentSupportType === SupportSubCategory.Lodging_Allowance ||
+          currentSupportType === SupportSubCategory.Lodging_Group)
+      ) {
         days = days + 1;
       }
       this.supportDetailsForm.get('noOfDays').patchValue(days);
@@ -789,6 +804,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
         : this.setDefaultTimes();
     }
   }
+
   private createFromDate() {
     let existingSupports = this.existingSupports.filter(
       (x) => x.status !== SupportStatus.Cancelled.toString() && x.status !== SupportStatus.Void.toString()

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -500,9 +500,16 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
    */
   updateValidToDate(days?: number): void {
     const currentVal = this.supportDetailsForm.get('fromDate').value;
+    const currentSupportType = this.stepSupportsService.supportTypeToAdd.value;
     if (days !== null && currentVal !== '') {
       const date = new Date(currentVal);
-      const finalValue = this.datePipe.transform(date.setDate(date.getDate() + days), 'MM/dd/yyyy');
+      const fromTime = this.supportDetailsForm.get('fromTime').value;
+      const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
+      let totalDays = days;
+      if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
+        totalDays -= 1;
+      }
+      const finalValue = this.datePipe.transform(date.setDate(date.getDate() + totalDays), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
     }
   }
@@ -516,13 +523,14 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     const days = this.supportDetailsForm.get('noOfDays').value;
     const currentVal = this.supportDetailsForm.get('fromDate').value;
     const fromTime = this.supportDetailsForm.get('fromTime').value;
+    const currentSupportType = this.stepSupportsService.supportTypeToAdd.value;
     const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
     const date = new Date(currentVal);
-    if (afterMidnightBeforeSix) {
-      let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days - 1), 'MM/dd/yyyy');
+    let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days), 'MM/dd/yyyy');
+    if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
+      finalValue = this.datePipe.transform(date.setDate(date.getDate() + days - 1), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
     } else {
-      let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
     }
   }
@@ -537,6 +545,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     const fromTime = this.supportDetailsForm.get('fromTime').value;
     const toDate = this.datePipe.transform(event.value, 'dd-MMM-yyyy');
     const dateDiff = new Date(toDate).getTime() - new Date(fromDate).getTime();
+    const currentSupportType = this.stepSupportsService.supportTypeToAdd.value;
     let days = dateDiff / (1000 * 60 * 60 * 24);
 
     const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
@@ -544,7 +553,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     if (days > 30) {
       this.supportDetailsForm.get('noOfDays').patchValue(null);
     } else {
-      if (afterMidnightBeforeSix) {
+      if (afterMidnightBeforeSix && (currentSupportType === SupportSubCategory.Lodging_Hotel || currentSupportType === SupportSubCategory.Lodging_Allowance || currentSupportType === SupportSubCategory.Lodging_Group)) {
         days = days + 1;
       }
       this.supportDetailsForm.get('noOfDays').patchValue(days);

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -29,7 +29,7 @@ import { AlertService } from 'src/app/shared/components/alert/alert.service';
 import { ReferralCreationService } from '../../step-supports/referral-creation.service';
 import { DateConversionService } from 'src/app/core/services/utility/dateConversion.service';
 import { ComputeRulesService } from 'src/app/core/services/computeRules.service';
-import {firstValueFrom, from, Subscription} from 'rxjs';
+import { firstValueFrom, Subscription } from 'rxjs';
 import { LoadEvacueeListService } from '../../../../core/services/load-evacuee-list.service';
 import {
   MatDatepickerInputEvent,
@@ -515,17 +515,16 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
   updateToDate(event: MatDatepickerInputEvent<Date>) {
     const days = this.supportDetailsForm.get('noOfDays').value;
     const currentVal = this.supportDetailsForm.get('fromDate').value;
-    const fromTime = this.supportDetailsForm.get('fromTime').value
-    const afterMidnightBeforeSix = this.isTimeBetween(fromTime, "00:00:00", "06:00:00")
+    const fromTime = this.supportDetailsForm.get('fromTime').value;
+    const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
     const date = new Date(currentVal);
-    if(afterMidnightBeforeSix){
-      let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days -1), 'MM/dd/yyyy');
+    if (afterMidnightBeforeSix) {
+      let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days - 1), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
-    }else{
+    } else {
       let finalValue = this.datePipe.transform(date.setDate(date.getDate() + days), 'MM/dd/yyyy');
       this.supportDetailsForm.get('toDate').patchValue(new Date(finalValue));
     }
-
   }
 
   /**
@@ -535,18 +534,18 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
    */
   updateNoOfDays(event: MatDatepickerInputEvent<Date>) {
     const fromDate = this.datePipe.transform(this.supportDetailsForm.get('fromDate').value, 'dd-MMM-yyyy');
-    const fromTime = this.supportDetailsForm.get('fromTime').value
+    const fromTime = this.supportDetailsForm.get('fromTime').value;
     const toDate = this.datePipe.transform(event.value, 'dd-MMM-yyyy');
     const dateDiff = new Date(toDate).getTime() - new Date(fromDate).getTime();
     let days = dateDiff / (1000 * 60 * 60 * 24);
 
-    const afterMidnightBeforeSix = this.isTimeBetween(fromTime, "00:00:00", "06:00:00")
+    const afterMidnightBeforeSix = this.isTimeBetween(fromTime, '00:00:00', '06:00:00');
 
     if (days > 30) {
       this.supportDetailsForm.get('noOfDays').patchValue(null);
     } else {
-      if(afterMidnightBeforeSix){
-        days = days + 1
+      if (afterMidnightBeforeSix) {
+        days = days + 1;
       }
       this.supportDetailsForm.get('noOfDays').patchValue(days);
     }
@@ -1013,7 +1012,7 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     fromTime.setHours(fromHours, fromMinutes, fromSeconds);
     const toTime = new Date();
     toTime.setHours(toHours, toMinutes, toSeconds);
-  //  Compare the times
+    //Compare the times
     return imputTime >= fromTime && imputTime <= toTime;
   }
   // Example usage:console.log(isTimeBefore("12:30:45", "14:20:15")); // trueconsole.log(isTimeBefore("18:00:00", "10:00:00")); // false

--- a/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/wizard/support-components/support-details/support-details.component.ts
@@ -291,13 +291,11 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
 
     this.createSupportDetailsForm();
     this.supportDetailsForm.get('noOfDays').valueChanges.subscribe((value) => {
-      console.log('value', value);
       this.updateValidToDate(value);
     });
 
     this.supportDetailsForm.get('fromDate').valueChanges.subscribe((value) => {
       if (value === null || value === '' || value === undefined) {
-        console.log('value', value);
         this.supportDetailsForm.get('noOfDays').patchValue(1);
       }
     });
@@ -1024,5 +1022,4 @@ export class SupportDetailsComponent implements OnInit, OnDestroy {
     //Compare the times
     return imputTime >= fromTime && imputTime <= toTime;
   }
-  // Example usage:console.log(isTimeBefore("12:30:45", "14:20:15")); // trueconsole.log(isTimeBefore("18:00:00", "10:00:00")); // false
 }


### PR DESCRIPTION
Allows the user to assign support for housing between the hours of 12am and 6am and have it count as the previous day.

Support starting at 4am Dec 17 and ending at 12pm Dec 17 counts as 1 day of support and will be reflected on the form.

1 day with same day end (1 night)
<img width="509" alt="image" src="https://github.com/user-attachments/assets/bb39e93b-436a-4859-a9aa-da29904bab1e" />

2 day with next day end (2 nights)
<img width="582" alt="image" src="https://github.com/user-attachments/assets/15bfc3c9-bd90-4255-8acc-7e991e918cf8" />
