### PR TITLE
ERA-27: ERA Printing Referrals on non-IOS tablets not working

### DIFF
--- a/responders/src/UI/embc-responder/src/app/core/services/utility/download.service.ts
+++ b/responders/src/UI/embc-responder/src/app/core/services/utility/download.service.ts
@@ -5,6 +5,14 @@ import { Injectable } from '@angular/core';
 })
 export class DownloadService {
   public downloadFile(win: Window, blob: Blob, fileName: string) {
+    // For Android tablets, force download for all content types
+    const isAndroidTablet = /android/i.test(navigator.userAgent) &&
+                           (window.innerWidth >= 600);
+
+    if (isAndroidTablet) {
+      return this.savePDF(win, blob, `${fileName}.pdf`);
+    }
+
     switch (blob.type) {
       case 'application/pdf':
         return this.savePDF(win, blob, fileName);

--- a/responders/src/UI/embc-responder/src/app/core/services/utility/download.service.ts
+++ b/responders/src/UI/embc-responder/src/app/core/services/utility/download.service.ts
@@ -6,8 +6,7 @@ import { Injectable } from '@angular/core';
 export class DownloadService {
   public downloadFile(win: Window, blob: Blob, fileName: string) {
     // For Android tablets, force download for all content types
-    const isAndroidTablet = /android/i.test(navigator.userAgent) &&
-                           (window.innerWidth >= 600);
+    const isAndroidTablet = /android/i.test(navigator.userAgent) && window.innerWidth >= 600;
 
     if (isAndroidTablet) {
       return this.savePDF(win, blob, `${fileName}.pdf`);


### PR DESCRIPTION
On Android, printing referrals previously resulted in a PDF that only captured a screenshot of the current screen. This fix ensures that the full referral content is included in the PDF, consistent with behavior on other operating systems:
![image](https://github.com/user-attachments/assets/a70c69f4-d405-4f69-97d9-e3418c5bb7fe)


We are still keeping the PDF functionality on browser:
![image](https://github.com/user-attachments/assets/d5baa081-a523-4ca0-9012-c13dafa297f0)


[Story](https://emcr.atlassian.net/browse/ERA-27)